### PR TITLE
use vscode storage for fql playground

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,7 @@ export async function activate(context: vscode.ExtensionContext) {
     languageService,
     outputChannel,
   );
-  const togglePlaygroundCommand = new TogglePlaygroundCommand();
+  const togglePlaygroundCommand = await TogglePlaygroundCommand.create(context);
 
   // The command has been defined in the package.json file
   // Now provide the implementation of the command with registerCommand


### PR DESCRIPTION
ENG-5510
The fql playgournd file will now use vscode storage instead of the users' project.  If the extension is active within a project, it will use vscode project storage.  This means that for each different project users' would have different playgrounds with different content. If not in a project it will use vscode global storage.