### PR TITLE
Bump to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/fauna/fauna-vscode"
   },
   "publisher": "Fauna",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "engines": {
     "vscode": "^1.72.0"
   },


### PR DESCRIPTION
We should release v0.1.0, so we can make semver-imcompatible upgrades, and so that we aren't on patch 0.0.1.
