### PR TITLE
rename config to fauna

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,13 +62,13 @@
       "title": "Fauna",
       "type": "object",
       "properties": {
-        "fauna-vscode.dbSecret": {
+        "fauna.dbSecret": {
           "type": "string",
           "default": "",
           "description": "The secret to use to connnect to your fauna database.",
           "scope": "window"
         },
-        "fauna-vscode.endpoint": {
+        "fauna.endpoint": {
           "type": "string",
           "default": "https://db.fauna.com",
           "description": "The fauna endpoint url to use. This should typically be 'https://db.fauna.com'.",
@@ -150,7 +150,7 @@
     "viewsWelcome": [
       {
         "view": "welcomeView",
-        "contents": "Welcome to the Fauna VSCode extension! To get started, configure your environment:\n[Configure Fauna Extension](command:workbench.action.openSettings?%22fauna-vscode%22)\nOnce configured, open the FQL Playground to begin writing queries!\n[Open FQL Playground](command:fauna-vscode.togglePlayground)\n"
+        "contents": "Welcome to the Fauna VSCode extension! To get started, configure your environment:\n[Configure Fauna Extension](command:workbench.action.openSettings?%22@ext:fauna.fauna-vscode%22)\nOnce configured, open the FQL Playground to begin writing queries!\n[Open FQL Playground](command:fauna-vscode.togglePlayground)\n"
       }
     ]
   }

--- a/src/FQLConfigurationManager.ts
+++ b/src/FQLConfigurationManager.ts
@@ -5,7 +5,7 @@ export class FQLConfigurationManager {
    * but will fail with correct error if an invalid one is present
    */
   static readonly EMPTY_SECRET = "0";
-  static readonly FAUNA_CONFIG_PATH = "fauna-vscode";
+  static readonly FAUNA_CONFIG_PATH = "fauna";
   static readonly SECRET_CONFIG_FIELD = "dbSecret";
   static readonly ENDPOINT_CONFIG_FIELD = "endpoint";
   static readonly SECRET_CONFIG_PATH = `${FQLConfigurationManager.FAUNA_CONFIG_PATH}.${FQLConfigurationManager.SECRET_CONFIG_FIELD}`;


### PR DESCRIPTION
Feels a bit weird to have the config titles include vscode.  Also figured out a better way to link directly to the extension configuration so it won't overlap with the previous extension config