### PR TITLE
Clarify developer setup and run the language server in fql` blocks in JS / TS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ node_modules
 # Logs
 yarn-debug.log*
 yarn-error.log*
+
+# Emacs
+*~
+*#

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,7 +1,19 @@
-## Developing the Extension
+# Developing the Extension
 
-Open vscode in this directory, and hit F5 to run a new version of
-vscode, which will have this plugin running.
+## Setup
+Before launching you'll need to fetch the analzyer locally and compile this app:
+
+```
+yarn developer-setup
+```
+
+
+## Launching
+Now to launch:
+
+Open vscode in this directory, and select "Run -> Start Debugging" from the menu,
+there is an `F5` shortcut for this on some systems with some keybindings. This will
+launch a parallel instance of VS code with the local extension running.
 
 Now in this new instance of vscode, press cmd+l/ctrl+l to open the FQL Playground.
 This should have syntax highlighting, and a language server should give live

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "Other"
   ],
   "activationEvents": [
-    "onLanguage:fql"
+    "onLanguage:fql",
+    "onLanguage:typescript"
   ],
   "main": "./out/extension.js",
   "dependencies": {
@@ -131,6 +132,22 @@
         "language": "fsl",
         "scopeName": "source.fsl",
         "path": "./syntax/fsl.tmGrammar.json"
+      },
+      {
+        "injectTo": [
+          "source.js",
+          "source.jsx",
+          "source.ts",
+          "source.tsx",
+          "text.html.basic",
+          "text.html.derivative",
+          "text.html.markdown"
+        ],
+        "scopeName": "meta.embedded.block.fql",
+        "path": "./syntax/fql.embedded.js.tmGrammar.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.fql": "source.fql"
+        }
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "vscode:prepublish": "yarn run compile",
     "compile": "tsc -p ./",
+    "developer-setup": "yarn install && yarn compile && yarn download-analyzer",
     "download-analyzer": "bash ./scripts/download-analyzer.sh",
     "watch": "tsc -watch -p ./",
     "pretest": "yarn run compile && yarn run lint && yarn run download-analyzer",
@@ -65,7 +66,7 @@
         "fauna.dbSecret": {
           "type": "string",
           "default": "",
-          "description": "The secret to use to connnect to your fauna database.",
+          "description": "The secret used to connect to your fauna database.",
           "scope": "window"
         },
         "fauna.endpoint": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/fauna/fauna-vscode"
   },
   "publisher": "Fauna",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "engines": {
     "vscode": "^1.72.0"
   },

--- a/syntax/fql.embedded.js.tmGrammar.json
+++ b/syntax/fql.embedded.js.tmGrammar.json
@@ -1,26 +1,34 @@
 {
   "scopeName": "meta.embedded.block.fql",
-  "begin": "(fql)(`)",
-  "end": "`",
-  "name": "meta.embedded.block.fql",
-  "beginCaptures": {
-    "0": {
-      "name": "punctuation.definition.string.begin.fql"
-    },
-    "1": {
-      "name": "punctuation.definition.string.begin.fql.backtick"
-    }
-  },
-  "endCaptures": {
-    "0": {
-      "name": "punctuation.definition.string.end.fql"
-    }
-  },
+  "injectionSelector": "L:source",
   "patterns": [
     {
-      "include": "source.fql"
+      "include": "#fql-block"
     }
-  ]
+  ],
+  "repository": {
+    "fql-block": {
+      "begin": "(fql)(`)",
+      "name": "meta.embedded.block.fql",
+      "end": "`",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.fql"
+        },
+        "1": {
+          "name": "punctuation.definition.string.begin.fql.backtick"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.fql"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.fql"
+        }
+      ]
+    }
+  }
 }
-
-

--- a/syntax/fql.embedded.js.tmGrammar.json
+++ b/syntax/fql.embedded.js.tmGrammar.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "fql-block": {
-      "begin": "(fql)(`)",
+      "begin": "(fql)\\W*(`)",
       "name": "meta.embedded.block.fql",
       "end": "`",
       "beginCaptures": {

--- a/syntax/fql.embedded.js.tmGrammar.json
+++ b/syntax/fql.embedded.js.tmGrammar.json
@@ -1,0 +1,26 @@
+{
+  "scopeName": "meta.embedded.block.fql",
+  "begin": "(fql)(`)",
+  "end": "`",
+  "name": "meta.embedded.block.fql",
+  "beginCaptures": {
+    "0": {
+      "name": "punctuation.definition.string.begin.fql"
+    },
+    "1": {
+      "name": "punctuation.definition.string.begin.fql.backtick"
+    }
+  },
+  "endCaptures": {
+    "0": {
+      "name": "punctuation.definition.string.end.fql"
+    }
+  },
+  "patterns": [
+    {
+      "include": "source.fql"
+    }
+  ]
+}
+
+


### PR DESCRIPTION
# Problem

- Developer setup is unclear and requires a bit of jumping around to figure out.
- cannot get inline syntax highlighting for FQL in JS / TS.

# Solution

- Make a yarn command for developer setup. Improve the DEVELOPERS.md README.
- Include an embedded grammar for inline syntax highlighting for JS / TS.

